### PR TITLE
fix double click when start a process (download, install or clone)

### DIFF
--- a/widgets/pages/page_clone.py
+++ b/widgets/pages/page_clone.py
@@ -80,6 +80,7 @@ class PageClone(QWidget):
         self.start_animation()
         self.append_selections(self.selections)
         self.start_clone(game_dir)
+        self.btn_install.setEnabled(False)
 
     def append_selections(self, selections: list[str]):
         for checkbox in self.cxb_list:
@@ -114,6 +115,7 @@ class PageClone(QWidget):
 
     @Slot(bool)
     def on_success(self, value: bool) -> None:
+        self.btn_install.setEnabled(True)
         if value:
             self.progress_bar.setRange(0, 100)
             self.progress_bar.setValue(100)
@@ -125,6 +127,7 @@ class PageClone(QWidget):
 
     @Slot(bool)
     def on_error(self, value: bool) -> None:
+        self.btn_install.setEnabled(True)
         if not value:
             self.progress_bar.setValue(0)
             self.progress_bar.setFormat("Failed shader proccess")

--- a/widgets/pages/page_download.py
+++ b/widgets/pages/page_download.py
@@ -96,6 +96,7 @@ class PageDownload(QWidget):
 
     @Slot(bool)
     def on_success(self, value: bool) -> None:
+        self.btn_download.setEnabled(True)
         if value:
             self.progress_bar.setRange(0, 100)
             self.progress_bar.setValue(100)
@@ -103,6 +104,7 @@ class PageDownload(QWidget):
 
     @Slot(bool)
     def on_error(self, value: bool) -> None:
+        self.btn_download.setEnabled(True)
         if not value:
             self.progress_bar.setRange(0, 100)
             self.progress_bar.setValue(0)
@@ -111,3 +113,4 @@ class PageDownload(QWidget):
     def click_download(self) -> None:
         self.start_animation()
         self.start_download()
+        self.btn_download.setEnabled(False)

--- a/widgets/pages/page_installation.py
+++ b/widgets/pages/page_installation.py
@@ -145,6 +145,7 @@ class PageInstallation(QWidget):
 
     def on_install_clicked(self) -> None:
         self.installation()
+        self.btn_install.setEnabled(False)
 
     @Slot(int)
     def update_progress(self, value: int) -> None:
@@ -152,12 +153,14 @@ class PageInstallation(QWidget):
 
     @Slot(bool)
     def on_sucess(self, value: bool) -> None:
+        self.btn_install.setEnabled(True)
         if value:
             self.progress_bar.setFormat("Installation finished!")
             self.install_finished.emit(value)
 
     @Slot(bool)
     def on_error(self, value: bool) -> None:
+        self.btn_install.setEnabled(True)
         if not value:
             self.progress_bar.setFormat("Error while installing")
             self.install_finished.emit(value)


### PR DESCRIPTION
- it prevents crashing the program