### PR TITLE
Fix native file dialog not working in AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         pyinstaller --noconfirm --onedir --windowed --clean \
           --name "LeShade" \
+          --runtime-hook "rthook.py" \
           --add-data "assets:assets" \
           --icon "assets/logo.png" \
           main.py

--- a/rthook.py
+++ b/rthook.py
@@ -1,0 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+base_path = Path(sys._MEIPASS)
+plugins_path = str(base_path / "PySide6" / "Qt" / "plugins")
+
+os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = plugins_path
+os.environ["QT_QPA_PLATFORMTHEME"] = "xdgdesktopportal"


### PR DESCRIPTION
### Description
When using the leshade-bin version from AUR, I noticed that the native file dialog wasn't working there, while it did work on the leshade-git version. After some digging, I was able to fix it, but I can only test on CachyOS. I have no way of testing other distros, and it is possible that the packaged binary won't work the same way in them, specially if you also use pyinstaller for them (that didn't look to be the case, though).

### Have you used AI to vibe code?
No.

### Have you used AI as a research source?
Yes, I'm not familiar with python binary packaging, so I used AI to help troubleshoot the issue and come up with a solution.

### Have you tested locally?
Yes. Though I had to do it with a much older version because the newest one won't open due to a github API rate limit when getting the renodx snapshots. In order to test it, you'll need to run the Build AppImage workflow, download the AppImage generated and execute it.

### Fixes:
Fix native file dialog not working specifically on the AppImage binary
