### PR TITLE
fix: infinite hang when installing renodx addon without shader pack

### DIFF
--- a/scripts_core/script_shaders.py
+++ b/scripts_core/script_shaders.py
@@ -118,6 +118,13 @@ class ShadersWorker(QObject):
             self.total_repos = len(self.selected_repos)
             current_repo: int = 0
 
+            # Download RenoDX addon asset if selected (must run even when no shader repos are selected)
+            renodx_url: str = f"https://github.com/clshortfuse/renodx/releases/download/snapshot/{self.selected_renodx_asset}"
+            renodx_asset_dir: str = os.path.join(
+                self.game_path, renodx_url.split("/")[-1].strip()
+            )
+            await self.download_renodx_asset(renodx_url, renodx_asset_dir)
+
             for repo_key in self.selected_repos:
                 repo_data: dict[str, str] | None = REPO_SHADERS.get(repo_key)
 
@@ -135,16 +142,7 @@ class ShadersWorker(QObject):
                     self.shader_temp_directory, f"{repo_name}.zip"
                 )
 
-                # RenoDX
-                renodx_url: str = f"https://github.com/clshortfuse/renodx/releases/download/snapshot/{self.selected_renodx_asset}"
-                renodx_asset_dir: str = os.path.join(
-                    self.game_path, renodx_url.split("/")[-1].strip()
-                )
-
-                await asyncio.gather(
-                    self.download_shaders(shader_url, zipped_shader_dir),
-                    self.download_renodx_asset(renodx_url, renodx_asset_dir),
-                )
+                await self.download_shaders(shader_url, zipped_shader_dir)
 
                 await self.unzip_shader(
                     self.shader_temp_directory, repo_name, zipped_shader_dir

--- a/widgets/pages/page_clone.py
+++ b/widgets/pages/page_clone.py
@@ -257,7 +257,7 @@ class PageClone(QWidget):
                 selections.append(checkbox.text())
 
     def start_clone(self, game_dir: str) -> None:
-        if not self.selections:
+        if not self.selections and self.renodx_addon.currentText() == "None":
             return
 
         self.clone_thread: QThread = QThread()


### PR DESCRIPTION
Hi! First of all thank you for this simple but very useful tool :smile:   

### Fixes:
Currently, when selecting a RenoDX addon without any shader pack, the app hangs indefinitely on the clone step. I noticed two issues (which I have fixed with this PR):
1. page_clone.py: start_clone() returned early when self.selections was empty, never emitting clone_finished even if a renodx addon was selected -> the wizard could not advance
2. script_shaders.py: the RenoDX download was nested inside the shader repo loop. When no repos were selected, the loop never executed and the addon was never downloaded

To fix that, I modified the guard condition in start_clone(), it now also allows progression when a RenoDX addon is selected. Also I extracted RenoDX download from the shader loop to always run.

**Have you used AI to vibe code?**
No
**Have you used AI as a research source?**
Yes
**Have you tested locally?**
Yes